### PR TITLE
Implement resilient bootstrap for offline setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+my-design-system/node_modules/
+offline-cache/*
+!offline-cache/README.md

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+strict-peer-dependencies=false
+shamefully-hoist=true

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NODE_REG="https://registry.npmjs.org"
+MIRROR_REG="https://registry.npmmirror.com"
+OFFLINE_CACHE="$(pwd)/offline-cache"
+
+function run_scaffold() {
+  local extra_args="$1"
+  if [ ! -d "my-design-system" ]; then
+    pnpm create vite my-design-system --template react-ts $extra_args
+  fi
+  cd my-design-system
+  pnpm add -D tailwindcss postcss autoprefixer @storybook/react vite-tsconfig-paths $extra_args
+  npx tailwindcss init -p
+  cd ..
+}
+
+ONLINE=1
+curl -sSf --connect-timeout 3 "$NODE_REG/-/ping" > /dev/null && ONLINE=0 || ONLINE=1
+
+if [ $ONLINE -eq 0 ]; then
+  echo "Online with main registry."
+  run_scaffold ""
+  exit 0
+fi
+
+# Try using mirror
+export NPM_CONFIG_REGISTRY="$MIRROR_REG"
+pnpm config set registry "$NPM_CONFIG_REGISTRY" > /dev/null
+
+if run_scaffold ""; then
+  exit 0
+fi
+
+# Fallback offline
+if [ -d "$OFFLINE_CACHE" ]; then
+  echo "Attempting offline install using $OFFLINE_CACHE"
+  pnpm config set store-dir "$OFFLINE_CACHE" > /dev/null
+  run_scaffold "--offline" && exit 0
+fi
+
+echo "Failed to bootstrap project. Check network connectivity or offline cache."
+exit 1

--- a/offline-cache/README.md
+++ b/offline-cache/README.md
@@ -1,0 +1,15 @@
+# Offline Cache
+
+To build in a fully offline environment, pre-populate pnpm's store on a machine with internet:
+
+```bash
+pnpm fetch create-vite@latest tailwindcss@latest postcss@latest autoprefixer@latest @storybook/react@latest vite-tsconfig-paths@latest
+```
+
+Archive the store and add it to this directory:
+
+```bash
+tar -czf offline-cache.tar.gz ~/.local/share/pnpm/store/v3
+```
+
+Place `offline-cache.tar.gz` here and extract before running `bootstrap.sh`.


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` to handle registry outages with mirror and offline cache support
- configure `.npmrc` for faster/offline installs
- document how to build an offline cache
- ignore node_modules and cache except README

## Testing
- `./bootstrap.sh` *(fails: ERR_PNPM_META_FETCH_FAIL due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6841b230fd84832487aebee731722a98