### PR TITLE
Add icon components and README

### DIFF
--- a/Cancel.jsx
+++ b/Cancel.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export const Cancel = ({ className = "", opacity = 1 }) => (
+  <svg
+    className={className}
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ opacity }}
+  >
+    <path
+      d="M12 4L4 12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M4 4L12 12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+Cancel.propTypes = {
+  className: PropTypes.string,
+  opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Design System
+
+This repository contains a very small collection of React components and
+supporting styles that can be used as the starting point for a design system.
+
+## Components
+
+- **ListElement** – renders a selectable list row. See `index.jsx` and
+  `style.css` for the implementation and styles.
+- **TypeBasicWrapper** – an input wrapper with different visual states.
+  Implemented in `index1.jsx` with styles in `style1.css`.
+- **Search** – simple search icon component.
+- **Cancel** – simple cancel (cross) icon component.
+
+All components are exported from `index.js` for convenience:
+
+```javascript
+import { ListElement, TypeBasicWrapper, Search, Cancel } from './index.js';
+```
+
+## Styles
+
+The `styleguide.css` file defines the CSS custom properties used throughout
+these components. Duplicate definitions also exist in `styleguide1.css`.
+
+## Usage
+
+These components are written in React and expect a bundler or build system
+that understands JSX. They can be imported individually or via `index.js`.

--- a/Search.jsx
+++ b/Search.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export const Search = ({ className = "", opacity = 1 }) => (
+  <svg
+    className={className}
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ opacity }}
+  >
+    <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+    <line
+      x1="16.5"
+      y1="16.5"
+      x2="22"
+      y2="22"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+Search.propTypes = {
+  className: PropTypes.string,
+  opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+export { ListElement } from "./index.jsx";
+export { TypeBasicWrapper } from "./index1.jsx";
+export { Cancel } from "./Cancel.jsx";
+export { Search } from "./Search.jsx";


### PR DESCRIPTION
## Summary
- implement simple `Cancel` and `Search` icon components
- export all components from `index.js`
- document the available components in a new `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841b6627be883249694ba7923c239b1